### PR TITLE
Add interactive web demo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ uvicorn
 
 # numpy for vector operations
 numpy
+gradio

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+# allow importing scripts as a package

--- a/web_demo.py
+++ b/web_demo.py
@@ -1,0 +1,61 @@
+# web_demo.py
+
+import os
+import json
+from typing import Tuple
+
+import gradio as gr
+
+from src.chatbot import PDFChatBot
+from scripts import pdf_extractor, chunker, build_index, section_rep_builder
+
+DEFAULT_PROMPT = (
+    "Answer the user's question based on the information provided in the document context below.\n"
+    "Your response should reference the context clearly, but you may paraphrase or summarize appropriately."
+)
+
+
+def process_pdf(pdf_path: str) -> Tuple[list, list]:
+    """Run the extraction/index pipeline for the given PDF."""
+    extracted = pdf_extractor.extract_pdf_content(pdf_path)
+    chunks = chunker.process_extracted_file(extracted)
+    chunk_index = build_index.build_chunk_index(chunks)
+    sections = section_rep_builder.build_section_reps(extracted["sections"], chunk_index)
+    return sections, chunk_index
+
+
+def load_pdf(pdf_file, system_prompt):
+    if pdf_file is None:
+        return None, None, "Please upload a PDF."
+    tmp_path = pdf_file.name
+    sections, chunk_index = process_pdf(tmp_path)
+    msg = f"Processed {os.path.basename(tmp_path)}"
+    return sections, chunk_index, msg
+
+
+def ask_question(question, sections, chunk_index, system_prompt):
+    if sections is None or chunk_index is None:
+        return "Please upload and process a PDF first."
+    prompt = system_prompt or DEFAULT_PROMPT
+    bot = PDFChatBot(sections, chunk_index, system_prompt=prompt)
+    return bot.answer(question)
+
+
+with gr.Blocks() as demo:
+    gr.Markdown("## QueryDoc Web Demo")
+    with gr.Row():
+        pdf_input = gr.File(label="PDF File", file_types=[".pdf"])
+        prompt_input = gr.Textbox(label="System Prompt", value=DEFAULT_PROMPT)
+        load_btn = gr.Button("Load PDF")
+    status = gr.Textbox(label="Status", interactive=False)
+    question_input = gr.Textbox(label="Question")
+    answer_output = gr.Textbox(label="Answer")
+
+    sections_state = gr.State()
+    index_state = gr.State()
+
+    load_btn.click(load_pdf, inputs=[pdf_input, prompt_input], outputs=[sections_state, index_state, status])
+    question_input.submit(ask_question, inputs=[question_input, sections_state, index_state, prompt_input], outputs=answer_output)
+
+if __name__ == "__main__":
+    demo.launch()


### PR DESCRIPTION
## Summary
- support customizable system prompt for chatbot
- add simple Gradio web demo to upload PDFs and test prompts
- allow `scripts` to be imported as a package
- include `gradio` in requirements

## Testing
- `python -m py_compile web_demo.py src/chatbot.py scripts/__init__.py`